### PR TITLE
Fonts are now loaded in over https

### DIFF
--- a/source/_includes/custom/head.html
+++ b/source/_includes/custom/head.html
@@ -1,3 +1,3 @@
 <!--Fonts from Google"s Web font directory at http://google.com/webfonts -->
-<link href='http://fonts.googleapis.com/css?family=Noto+Serif:400,700' rel='stylesheet' type='text/css'>
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Noto+Serif:400,700' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Fonts are now loaded in over https so that chrome doesn't block the fonts and complain about loading insecure content. Fixes #2
