### PR TITLE
change date_formatted to date_text

### DIFF
--- a/source/_includes/post/date.html
+++ b/source/_includes/post/date.html
@@ -1,9 +1,9 @@
 {% capture date %}{{ page.date }}{{ post.date }}{% endcapture %}
-{% capture date_formatted %}{{ page.date_formatted }}{{ post.date_formatted }}{% endcapture %}
+{% capture date_formatted %}{{ page.date_text }}{{ post.date_text }}{% endcapture %}
 {% capture has_date %}{{ date | size }}{% endcapture %}
 
 {% capture updated %}{{ page.updated }}{{ post.updated }}{% endcapture %}
-{% capture updated_formatted %}{{ page.updated_formatted }}{{ post.updated_formatted }}{% endcapture %}
+{% capture updated_formatted %}{{ page.updated_text }}{{ post.updated_text }}{% endcapture %}
 {% capture was_updated %}{{ updated | size }}{% endcapture %}
 
 {% if has_date != '0' %}


### PR DESCRIPTION
Publish date of post is not displayed since `page.date_formatted` attribute does not exist. It should be `page.date_text`.