### PR TITLE
Change layout from nil to null to prevent warning

### DIFF
--- a/source/_includes/custom/category_feed.xml
+++ b/source/_includes/custom/category_feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 User-agent: *
 Disallow: 


### PR DESCRIPTION
Since upgrading my Octopress blog (or perhaps Jekyll), I get the following warnings when building:

```
     Build Warning: Layout 'nil' requested in blog/categories/git/atom.xml does not exist.
     Build Warning: Layout 'nil' requested in blog/categories/ruby/atom.xml does not exist.
     Build Warning: Layout 'nil' requested in blog/categories/rails/atom.xml does not exist.
     Build Warning: Layout 'nil' requested in blog/categories/http/atom.xml does not exist.
     Build Warning: Layout 'nil' requested in blog/categories/chrome/atom.xml does not exist.
```

This is fixed by changing all instances of `layout: nil` to `layout: null`. 

See https://github.com/jekyll/jekyll-help/issues/112 where this is discussed further.

Love the theme by the way, just updated my blog to use it! Thanks!
