### PR TITLE
Adds cleaner option to enable/disable sticky header

### DIFF
--- a/source/_includes/custom/after_footer.html
+++ b/source/_includes/custom/after_footer.html
@@ -1,7 +1,12 @@
 {% comment %}
   Add content to be output at the bottom of each page. (You might use this for analytics scripts, for example)
 {% endcomment %}
-{% if true %}
+
+{% if true or site.sticky_header %}
+  {% comment %}
+  Note that if you define `sticky_header: false` in _config.yml, the `true` above
+  must be removed.
+  {% endcomment %}
   <script>
     $(document).ready(function() {
       var stickyNavTop = $('nav').offset().top;

--- a/source/_includes/custom/after_footer.html
+++ b/source/_includes/custom/after_footer.html
@@ -1,29 +1,31 @@
 {% comment %}
   Add content to be output at the bottom of each page. (You might use this for analytics scripts, for example)
 {% endcomment %}
-<script>
-  $(document).ready(function() {  
-    var stickyNavTop = $('nav').offset().top;  
-      
-    var stickyNav = function(){  
-      var scrollTop = $(window).scrollTop(); 
-      var navHasClassSticky = $('nav').hasClass('sticky');
+{% if true %}
+  <script>
+    $(document).ready(function() {
+      var stickyNavTop = $('nav').offset().top;
 
-      if (scrollTop > stickyNavTop && navHasClassSticky) {   
-        return true;
-      } else if (scrollTop > stickyNavTop) {
-        $('nav').hide();
-        $('nav').addClass('sticky');
-        $('nav').fadeIn('2000');
-      } else {  
-        $('nav').removeClass('sticky');   
-      }  
-    };  
-      
-    stickyNav();  
-      
-    $(window).scroll(function() {  
-      stickyNav();  
-    });  
-  });  
-</script>
+      var stickyNav = function(){
+        var scrollTop = $(window).scrollTop();
+        var navHasClassSticky = $('nav').hasClass('sticky');
+
+        if (scrollTop > stickyNavTop && navHasClassSticky) {
+          return true;
+        } else if (scrollTop > stickyNavTop) {
+          $('nav').hide();
+          $('nav').addClass('sticky');
+          $('nav').fadeIn('2000');
+        } else {
+          $('nav').removeClass('sticky');
+        }
+      };
+
+      stickyNav();
+
+      $(window).scroll(function() {
+        stickyNav();
+      });
+    });
+  </script>
+{% endif %}


### PR DESCRIPTION
This pull request allows an easy option to enable/disable the sticky header. In _config.yml, the variable `sticky_header: true` or `sticky_header: false` can be included.

By default, the sticky header remains enabled. In [`after_footer.html`](https://github.com/scottsievert/boldandblue/blob/master/source/_includes/custom/after_footer.html#L5), there is an if statement that enables the sticky header if `true or site.sticky_header`. Just below this if statement, there is a comment explaining that modification of the source file is necessary if `site.sticky_header` is defined.

I tried to detect if `site.sticky_header` was defined in _config.yml but ran into unexpected difficulties.
